### PR TITLE
Fix color space mismatch

### DIFF
--- a/utils/merge_tiles.py
+++ b/utils/merge_tiles.py
@@ -162,7 +162,7 @@ def do_merge_tiles(context: Context, tiles: List[MergeTile]) -> None:
 
     final_image = bpy.data.images.new(final_image_name, alpha=True, float_buffer=True, width=res_x, height=res_y)
     final_image.alpha_mode = 'STRAIGHT'
-    final_image.colorspace_settings.name = 'Linear'
+    final_image.colorspace_settings.name = 'Linear Rec.709'
     final_image.generated_type = 'BLANK'
     final_image.filepath_raw = final_image_filepath
     final_image.file_format = render.image_settings.file_format
@@ -181,3 +181,4 @@ def do_merge_tiles(context: Context, tiles: List[MergeTile]) -> None:
     bpy.data.images.remove(final_image)
     final_image = None
     gc.collect()
+


### PR DESCRIPTION
New blender versions don't accept "Linear" as a color space name. I have changed it to "Linear Red.709" as that is the closest color space.
It seems that other than this problem, it works mostly fine on Blender 5.0, however some errors still show up the terminal.

Changes proposed in this pull request:
- Change line 165 in merge_tiles.py to account for Blender's color space changes.

Fixes #.

